### PR TITLE
Fix status change bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # apcups-exporter
 Prometheus Exporter for APC UPS hardware via apcupsd
+
+## UPS Status
+
+The exporter lists two different types of status metric to be as flexible as possible.
+
+1. `apc_status` has a label value of "status" which includes all the possible apcupsd status values, currently this results in the following for an "online" UPS:
+
+```
+# HELP apcups_status Current status of UPS
+# TYPE apcups_status gauge
+apcups_status{hostname="beaker.murf.org",status="boost",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="commlost",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="lowbatt",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="nobatt",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="onbatt",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="online",upsname="backups-950"} 1
+apcups_status{hostname="beaker.murf.org",status="overload",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="replacebatt",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="shutting down",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="slave",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="slavedown",upsname="backups-950"} 0
+apcups_status{hostname="beaker.murf.org",status="trim",upsname="backups-950"} 0
+```
+
+2. `apc_status_numeric` is a single metric with value as per the following status table
+| status        | value |
+|---------------|-------|
+| online        | 0     |
+| trim          | 1     |
+| boost         | 2     |
+| onbatt        | 3     |
+| overload      | 4     |
+| lowbatt       | 5     |
+| replacebatt   | 6     |
+| nobatt        | 7     |
+| slave         | 8     |
+| slavedown     | 9     |
+| commlost      | 10    |
+| shutting down | 11    |
+
+

--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ apcups_status{hostname="beaker.murf.org",status="trim",upsname="backups-950"} 0
 | status        | value |
 |---------------|-------|
 | online        | 0     |
-| trim          | 1     |
-| boost         | 2     |
-| onbatt        | 3     |
-| overload      | 4     |
-| lowbatt       | 5     |
-| replacebatt   | 6     |
-| nobatt        | 7     |
-| slave         | 8     |
-| slavedown     | 9     |
-| commlost      | 10    |
-| shutting down | 11    |
+| onbatt        | 1     |
+| trim          | 2     |
+| boost         | 3     |
+| onbatt        | 4     |
+| overload      | 5     |
+| lowbatt       | 6     |
+| replacebatt   | 7     |
+| nobatt        | 8     |
+| slave         | 9     |
+| slavedown     | 10    |
+| commlost      | 11    |
+| shutting down | 12    |
 
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ apcups_status{hostname="beaker.murf.org",status="trim",upsname="backups-950"} 0
 ```
 
 2. `apc_status_numeric` is a single metric with value as per the following status table
+
 | status        | value |
 |---------------|-------|
 | online        | 0     |

--- a/main.go
+++ b/main.go
@@ -42,9 +42,9 @@ type upsInfo struct {
 // list of statuses.
 var statusList = []string{
 	"online",
+	"onbatt",
 	"trim",
 	"boost",
-	"onbatt",
 	"overload",
 	"lowbatt",
 	"replacebatt",

--- a/main.go
+++ b/main.go
@@ -38,6 +38,23 @@ type upsInfo struct {
 	upsName  string
 }
 
+// See SVN code at https://sourceforge.net/p/apcupsd/svn/HEAD/tree/trunk/src/lib/apcstatus.c#l166 for
+// list of statuses.
+var statusList = []string{
+	"online",
+	"trim",
+	"boost",
+	"onbatt",
+	"overload",
+	"lowbatt",
+	"replacebatt",
+	"nobatt",
+	"slave",
+	"slavedown",
+	"commlost",
+	"shutting down",
+}
+
 var (
 	labels = []string{"hostname", "upsname"}
 
@@ -46,6 +63,13 @@ var (
 		Help: "Current status of UPS",
 	},
 		append(labels, "status"),
+	)
+
+	statusNumeric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "apcups_status_numeric",
+		Help: "Current status of UPS represented as integer",
+	},
+		labels,
 	)
 
 	nominalPower = prometheus.NewGaugeVec(prometheus.GaugeOpts{
@@ -137,6 +161,7 @@ func main() {
 	log.Printf("Metric listener at: %s", *addr)
 
 	prometheus.MustRegister(status)
+	prometheus.MustRegister(statusNumeric)
 	prometheus.MustRegister(nominalPower)
 	prometheus.MustRegister(batteryChargePercent)
 	prometheus.MustRegister(timeOnBattery)
@@ -181,6 +206,15 @@ func collectUPSData(upsAddr *string) error {
 	collectSeconds.WithLabelValues(info.hostname, info.upsName).Set(gatherDuration.Seconds())
 
 	log.Printf("%+v", info)
+
+	for i, stat := range statusList {
+		if stat == info.status {
+			status.WithLabelValues(info.hostname, info.upsName, stat).Set(1)
+			statusNumeric.WithLabelValues(info.hostname, info.upsName).Set(float64(i))
+		} else {
+			status.WithLabelValues(info.hostname, info.upsName, stat).Set(0)
+		}
+	}
 
 	status.WithLabelValues(info.hostname, info.upsName, info.status).Set(1)
 


### PR DESCRIPTION
This PR addresses #2 by ensuring that the original functionality of apcups_status works as intended, i.e.: a metric labelled by status resets itself to zero once the UPS is no longer in that status. Additionally, to assist with Grafana use-cases, another metric `apc_status_numeric` has been created that represents all possibly statuses within one metric. See the README for more information.