### PR TITLE
[fixed] continue parsing if a certain key in the output of apcupsd is…

### DIFF
--- a/main.go
+++ b/main.go
@@ -316,6 +316,9 @@ func parseTime(t string) (time.Duration, error) {
 
 // parse generic units, splitting of units name and converting to float
 func parseUnits(v string) (float64, error) {
+	if v == ""{
+		return 0, nil
+	}
 	return strconv.ParseFloat(strings.Split(v, " ")[0], 32)
 }
 


### PR DESCRIPTION
My UPS doesn't export the _NOMPOWER_ metric. Because of that, the exporter would fail at
```go
	if nomPower, err := parseUnits(ups["NOMPOWER"]); err != nil {
```
If a certain key wasn't found in the output, the exporter will now simply return 0 in that case.